### PR TITLE
Dynamic contact tracing

### DIFF
--- a/sim/lib/dynamics.py
+++ b/sim/lib/dynamics.py
@@ -34,7 +34,7 @@ class DiseaseModel(object):
             object of class MobilitySimulator providing mobility data
 
         dynamic_tracing: bool
-            If true contacts are computed on-the-fly during launch_simulation
+            If true contacts are computed on-the-fly during launch_epidemic
             instead of using the previously filled contact array
 
         """
@@ -681,7 +681,7 @@ class DiseaseModel(object):
 
             valid_contacts = valid_j()
         else:
-            infectors_contacts = self.mob.find_contacts_of_indiv(self.mob.all_mob_traces, indiv=infector, tmin=t)
+            infectors_contacts = self.mob.find_contacts_of_indiv(indiv=infector, tmin=t)
 
             valid_contacts = []
             for contact in infectors_contacts:
@@ -884,8 +884,7 @@ class DiseaseModel(object):
 
             valid_contacts = valid_j()
         else:
-            infectors_contacts = self.mob.find_contacts_of_indiv(self.mob.all_mob_traces, indiv=i,
-                                                                 tmin=t - self.test_smart_delta)
+            infectors_contacts = self.mob.find_contacts_of_indiv(indiv=i, tmin=t - self.test_smart_delta)
             valid_contacts = []
 
             for contact in infectors_contacts:

--- a/sim/lib/dynamics.py
+++ b/sim/lib/dynamics.py
@@ -277,8 +277,6 @@ class DiseaseModel(object):
                 else:
                     raise ValueError('Invalid initial seed state.')
 
-    from lib.timing import timeit
-    @timeit
     def launch_epidemic(self, params, initial_counts, testing_params, measure_list, verbose=True):
         """
         Run the epidemic, starting from initial event list.

--- a/sim/lib/mobilitysim.py
+++ b/sim/lib/mobilitysim.py
@@ -536,6 +536,11 @@ class MobilitySimulator:
         return all_mob_traces
 
     def _find_contacts(self):
+        """
+        Finds contacts in a given list `mob_traces` of `Visit`s
+        and stores them in a dictionary of dictionaries of InterLap objects,
+        """
+        # Group mobility traces by site
         mob_traces_at_site = defaultdict(list)
         for v in self.all_mob_traces:
             mob_traces_at_site[v.site].append(v)

--- a/sim/lib/parallel.py
+++ b/sim/lib/parallel.py
@@ -34,7 +34,7 @@ class ParallelSummary(object):
     Summary class of several restarts
     """
 
-    def __init__(self, max_time, repeats, n_people, n_sites, site_loc, home_loc):
+    def __init__(self, max_time, repeats, n_people, n_sites, site_loc, home_loc, dynamic_tracing):
 
         self.max_time = max_time
         self.random_repeats = repeats
@@ -42,6 +42,7 @@ class ParallelSummary(object):
         self.n_sites = n_sites
         self.site_loc = site_loc
         self.home_loc = home_loc
+        self.dynamic_tracing = dynamic_tracing
        
         self.state = {
             'susc': np.ones((repeats, n_people), dtype='bool'),
@@ -93,7 +94,8 @@ class ParallelSummary(object):
 
 def create_ParallelSummary_from_DiseaseModel(sim):
 
-    summary = ParallelSummary(sim.max_time, 1, sim.n_people, sim.mob.num_sites, sim.mob.site_loc, sim.mob.home_loc)
+    summary = ParallelSummary(sim.max_time, 1, sim.n_people, sim.mob.num_sites, sim.mob.site_loc, sim.mob.home_loc,
+                              sim.dynamic_tracing)
 
     for code in pp_legal_states:
         summary.state[code][0, :] = sim.state[code]
@@ -112,12 +114,12 @@ def create_ParallelSummary_from_DiseaseModel(sim):
     return summary
 
 
-def pp_launch(r, kwargs, distributions, params, initial_counts, testing_params, measure_list, max_time):
+def pp_launch(r, kwargs, distributions, params, initial_counts, testing_params, measure_list, max_time, dynamic_tracing):
 
     mob = MobilitySimulator(**kwargs)
-    mob.simulate(max_time=max_time)
+    mob.simulate(max_time=max_time, dynamic_tracing=dynamic_tracing)
 
-    sim = DiseaseModel(mob, distributions)
+    sim = DiseaseModel(mob, distributions, dynamic_tracing=dynamic_tracing)
 
     sim.launch_epidemic(
         params=params,
@@ -143,8 +145,8 @@ def pp_launch(r, kwargs, distributions, params, initial_counts, testing_params, 
 
 
 def launch_parallel_simulations(mob_settings, distributions, random_repeats, cpu_count, params, 
-    initial_seeds, testing_params, measure_list, max_time, num_people, num_sites, site_loc, home_loc, 
-    verbose=True, synthetic=False):
+    initial_seeds, testing_params, measure_list, max_time, num_people, num_sites, site_loc, home_loc,
+                                dynamic_tracing=False, verbose=True, synthetic=False):
     
 
     with open(mob_settings, 'rb') as fp:
@@ -157,6 +159,7 @@ def launch_parallel_simulations(mob_settings, distributions, random_repeats, cpu
     initial_seeds_list = [copy.deepcopy(initial_seeds) for _ in range(random_repeats)]
     testing_params_list = [copy.deepcopy(testing_params) for _ in range(random_repeats)]
     max_time_list = [copy.deepcopy(max_time) for _ in range(random_repeats)]
+    dynamic_tracing = [copy.deepcopy(dynamic_tracing) for _ in range(random_repeats)]
     repeat_ids = list(range(random_repeats))
 
     if verbose:
@@ -164,10 +167,10 @@ def launch_parallel_simulations(mob_settings, distributions, random_repeats, cpu
 
     with ProcessPoolExecutor(cpu_count) as ex:
         res = ex.map(pp_launch, repeat_ids, mob_setting_list, distributions_list, params_list,
-                     initial_seeds_list, testing_params_list, measure_list_list, max_time_list)
+                     initial_seeds_list, testing_params_list, measure_list_list, max_time_list, dynamic_tracing)
     
     # collect all result (the fact that mob is still available here is due to the for loop)
-    summary = ParallelSummary(max_time, random_repeats, num_people, num_sites, site_loc, home_loc)
+    summary = ParallelSummary(max_time, random_repeats, num_people, num_sites, site_loc, home_loc, dynamic_tracing)
     
     for r, result in enumerate(res):
 


### PR DESCRIPTION
Added a dynamic matching of mobility traces, so that contacts are computed as needed during the simulation instead of computing and storing the array of all contacts beforehand in MobilitySimulator.simulate().

Whenever a person gets infected at time t, their contacts are computed with the new method MobilitySimulator.find_contacts_indiv(mob_traces, infector, t) and added to the initially empty MobilitySimulator.contacts array which is subsequently used as before.

The argument mob_traces in find_contacts_indiv has to be an array of Visit() objects. If MobilitySimulator.simulate() is run with dynamic_tracing=True, this is stored as MobilitySimulator.all_mob_traces. This is different from the dictionary MobilitySimulator.mob_traces.
If MobilitySimulator.mob_traces is not needed somewhere else one could think about replacing it.

To run simulations with dynamic contact tracing simply run 
launch_parallel_simulations(args, dynamic_tracing=True)

or on a lower level using an instance mob of MobilitySimulator()
mob.simulate(args, dynamic_tracing=True)
DiseaseModel(args, dynamic_tracing=True)

The default is always dynamic_tracing=False.